### PR TITLE
Add epoch version to change data messages

### DIFF
--- a/cdc_kafka/__init__.py
+++ b/cdc_kafka/__init__.py
@@ -5,7 +5,7 @@ import sentry_sdk
 
 sentry_sdk.init()
 
-VERSION = "4.4.1"
+VERSION = "4.5.0"
 
 log_level = os.getenv('LOG_LEVEL', 'INFO').upper()
 

--- a/cdc_kafka/constants.py
+++ b/cdc_kafka/constants.py
@@ -86,6 +86,7 @@ LSN_NAME = '__log_lsn'
 COMMAND_ID_NAME = '__command_id'
 SEQVAL_NAME = '__log_seqval'
 UPDATED_FIELDS_NAME = '__updated_fields'
+EPOCH_VERSION_NAME = '__epoch_version'
 
 DB_LSN_COL_NAME = '__$start_lsn'
 DB_COMMAND_ID_COL_NAME = '__$command_id'

--- a/cdc_kafka/options.py
+++ b/cdc_kafka/options.py
@@ -284,6 +284,12 @@ def get_options_and_metrics_reporters(
                    default=os.environ.get('DB_ROW_BATCH_SIZE', 2000),
                    help="Maximum number of rows to retrieve in a single change data or snapshot query. Default 2000.")
 
+    p.add_argument('--epoch-version',
+                   type=int,
+                   default=int(os.environ.get('EPOCH_VERSION', 1)),
+                   help="Integer epoch version included as the `__epoch_version` field in every change data message. "
+                        "Increment this value to signal a breaking schema or semantic change to consumers. Default 1.")
+
     kafka_oauth.add_kafka_oauth_arg(p)
     if arg_adder:
         arg_adder(p)

--- a/cdc_kafka/serializers/avro.py
+++ b/cdc_kafka/serializers/avro.py
@@ -400,6 +400,11 @@ class AvroSchemaGenerator(object):
                         "symbols": [constants.UNRECOGNIZED_COLUMN_DEFAULT_NAME] + source_field_names
                     }
                 }
+            },
+            {
+                "name": constants.EPOCH_VERSION_NAME,
+                "type": "int",
+                "default": 1
             }
         ]
 
@@ -407,10 +412,12 @@ class AvroSchemaGenerator(object):
 class AvroSerializer(SerializerAbstract):
     def __init__(self, schema_registry_url: str, always_use_avro_longs: bool, progress_topic_name: str,
                  snapshot_logging_topic_name: str, metrics_topic_name: str,
-                 avro_type_spec_overrides: Dict[str, str | Dict[str, str | int]], disable_writes: bool) -> None:
+                 avro_type_spec_overrides: Dict[str, str | Dict[str, str | int]], disable_writes: bool,
+                 epoch_version: int = 1) -> None:
         self.always_use_avro_longs: bool = always_use_avro_longs
         self.avro_type_spec_overrides: Dict[str, str | Dict[str, str | int]] = avro_type_spec_overrides
         self.disable_writes: bool = disable_writes
+        self._epoch_version: int = epoch_version
         self._schema_registry: confluent_kafka.avro.CachedSchemaRegistryClient = \
             confluent_kafka.avro.CachedSchemaRegistryClient(schema_registry_url)  # type: ignore[call-arg]
         self._confluent_serializer: confluent_kafka.avro.MessageSerializer = \
@@ -541,6 +548,7 @@ class AvroSerializer(SerializerAbstract):
                 if bit:
                     int_to_int(value_writer, i + 1)
             value_writer.write(b'\x00')
+        int_to_int(value_writer, self._epoch_version)
         for ix, f in enumerate(metadata.ordered_serializers):
             if row.table_data_cols[ix] is None:
                 value_writer.write(b'\x00')
@@ -589,6 +597,7 @@ class AvroSerializer(SerializerAbstract):
             value_dict[constants.UPDATED_FIELDS_NAME] = list(metadata.value_field_names)
 
         value_dict[constants.EVENT_TIME_NAME] = row.event_db_time.isoformat()
+        value_dict[constants.EPOCH_VERSION_NAME] = self._epoch_version
         dates_transformed = {k: v.isoformat() for k, v in value_dict.items() if type(v) is datetime.datetime}
         value_dict.update(dates_transformed)
 
@@ -671,7 +680,7 @@ class AvroSerializer(SerializerAbstract):
         metrics_topic_name: str = hasattr(opts, 'kafka_metrics_topic') and opts.kafka_metrics_topic or ''
         return cls(opts.schema_registry_url, opts.always_use_avro_longs, opts.progress_topic_name,
                    opts.snapshot_logging_topic_name, metrics_topic_name, opts.avro_type_spec_overrides,
-                   disable_writes)
+                   disable_writes, opts.epoch_version)
 
 
 def decimal_to_decimal(writer: io.BytesIO, datum: decimal.Decimal, scale: int) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sqlserver-cdc-to-kafka"
-version = "4.4.1"
+version = "4.5.0"
 description = "Stream SQL Server Change Data Capture (CDC) events to Apache Kafka"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
This adds a new field `__epoch_version` (integer, default 1) to produced change data messages, which can be used to signal LSN reversions or other major / possibly incompatible changes in the stream of events when necessary.